### PR TITLE
error messages for unresolved dependencies

### DIFF
--- a/lib/israkel/tasks.rb
+++ b/lib/israkel/tasks.rb
@@ -15,10 +15,6 @@ module ISRakel
 
       yield self if block_given?
 
-      # Make sure all external commands are in the PATH.
-      xcode_path
-      ios_sim_path
-
       define_reset_task
       define_set_language_task
       define_start_task


### PR DESCRIPTION
check if ios_sim_path or xcode_path are empty and report sensible errors. Also dont call them on startup to allow rake -T to run without showing an error.
